### PR TITLE
fix: duplicate method name

### DIFF
--- a/cloudwatch_elk.groovy
+++ b/cloudwatch_elk.groovy
@@ -203,7 +203,7 @@ class CloudWatchElasticLoader {
     }
 }
 
-def main(String[] args) {
+def app_main(String[] args) {
     final ES_HOST_DEFAULT = 'localhost'
     final String ES_CLUSTER_DEFAULT = 'cloudwatch-cluster'
     final int ES_PORT_DEFAULT = 9300
@@ -243,4 +243,4 @@ def main(String[] args) {
     }
 }
 
-main(args)
+app_main(args)


### PR DESCRIPTION
Fix for this error:

```
<@cloudwatch-elk>-<⎇ fix_startup>-> groovy cloudwatch_elk.groovy
org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
/Users/cathleenturner/code/catch/cloudwatch-elk/cloudwatch_elk.groovy: 206: The method public java.lang.Object main([Ljava.lang.String; args)  { ... } duplicates another method of the same signature
. At [206:1]  @ line 206, column 1.
   def main(String[] args) {
   ^

1 error
```